### PR TITLE
Removes stunbaton's mindshield restriction

### DIFF
--- a/modular_skyrat/modules/blueshield/code/game/objects/items/melee/misc.dm
+++ b/modular_skyrat/modules/blueshield/code/game/objects/items/melee/misc.dm
@@ -16,8 +16,3 @@
 	w_class = WEIGHT_CLASS_SMALL //small but packs a PUNCH.
 	preload_cell_type = /obj/item/stock_parts/cell/high/plus
 
-/obj/item/melee/baton/attack(mob/M, mob/living/carbon/human/user)
-	if(!HAS_TRAIT(user, TRAIT_MINDSHIELD))
-		to_chat(user, "<span class='danger'>A red light on the baton flashes!</span>")
-		return TRUE
-	..()


### PR DESCRIPTION
## Changelog
:cl: Russo
tweak: Removed stunbaton's mindshield restriction
fix: Abductor can now use their baton as it doesn't need mindshield implant anymore
/:cl: